### PR TITLE
fix: :adhesive_bandage: use curly brackets for parameter list generation

### DIFF
--- a/src/c3/generate_kfp_component.ipynb
+++ b/src/c3/generate_kfp_component.ipynb
@@ -277,10 +277,10 @@
     "    return_value = str()\n",
     "    index = 0\n",
     "    for output_key, output_value in outputs.items():\n",
-    "        return_value = return_value + output_key + '=\"$' + str(index) + '\" '\n",
+    "        return_value = return_value + output_key + '=\"${' + str(index) + '}\" '\n",
     "        index = index + 1\n",
     "    for input_key, input_value in inputs.items():\n",
-    "        return_value = return_value + input_key + '=\"$' + str(index) + '\" '\n",
+    "        return_value = return_value + input_key + '=\"${' + str(index) + '}\" '\n",
     "        index = index + 1\n",
     "    return return_value      "
    ]


### PR DESCRIPTION
Related to [issue-6](https://github.com/claimed-framework/c3/issues/6)