### PR TITLE
add nbformat requirement to python docker template

### DIFF
--- a/src/c3/templates/python_dockerfile_template
+++ b/src/c3/templates/python_dockerfile_template
@@ -2,7 +2,7 @@ FROM registry.access.redhat.com/ubi8/python-39
 USER root
 ADD ${target_code} ${working_dir}${target_dir}
 ${additional_files_docker}
-RUN pip install ipython
+RUN pip install ipython nbformat
 ${requirements_docker}
 RUN chmod -R 777 ${working_dir}
 USER default


### PR DESCRIPTION
without nbformat, python notebook components are failing