### PR TITLE
Moved operator code in dockerfile template

### DIFF
--- a/src/c3/templates/python_dockerfile_template
+++ b/src/c3/templates/python_dockerfile_template
@@ -1,10 +1,10 @@
 FROM registry.access.redhat.com/ubi8/python-39
 USER root
-ADD ${target_code} ${working_dir}${target_dir}
 ${additional_files_docker}
 RUN pip install --upgrade pip
 RUN pip install ipython nbformat
 ${requirements_docker}
+ADD ${target_code} ${working_dir}${target_dir}
 RUN chmod -R 777 ${working_dir}
 USER default
 WORKDIR "${working_dir}"


### PR DESCRIPTION
Moved adding the operator code after the pip install steps in the dockerfile template. Rebuilding an operator should happen faster, as the pip install layers can be reused.

Additional files are added before pip install, as they might be required for installing packages etc.